### PR TITLE
feat: Implement initial version of MacForge3D

### DIFF
--- a/MacForge3D/UI/components/ThreeDPreviewView.swift
+++ b/MacForge3D/UI/components/ThreeDPreviewView.swift
@@ -1,70 +1,97 @@
 import SwiftUI
 import SceneKit
 
+/// A SwiftUI view that displays a 3D model from a file URL using SceneKit.
 struct ThreeDPreviewView: View {
-    var filePath: String?
+    // The URL of the 3D model file to display.
+    let modelURL: URL
 
-    var body: some View {
-        if let path = filePath {
-            // Check if the file exists before trying to load it
-            if FileManager.default.fileExists(atPath: path) {
-                SceneKitView(scene: loadScene(from: path))
-            } else {
-                Text("Error: Model file not found at \(path)")
-                    .foregroundColor(.red)
-            }
-        } else {
-            // If no file path is provided, show a placeholder view
-            Text("3D Preview")
-                .foregroundColor(.gray)
+    // The SceneKit scene that will be loaded.
+    private let scene: SCNScene?
+
+    // A flag to indicate if the model failed to load.
+    private var didFailToLoad: Bool {
+        scene == nil
+    }
+
+    init(modelURL: URL) {
+        self.modelURL = modelURL
+
+        // Attempt to load the scene from the URL.
+        // This is a failable initializer, so we handle the nil case.
+        do {
+            self.scene = try SCNScene(url: modelURL, options: [
+                .checkConsistency: true,
+                .flattenScene: true,
+                .createNormalsIfAbsent: true
+            ])
+        } catch {
+            print("❌ Failed to load scene from URL: \(modelURL). Error: \(error)")
+            self.scene = nil
         }
     }
 
-    private func loadScene(from path: String) -> SCNScene? {
-        do {
-            let url = URL(fileURLWithPath: path)
-            // SCNScene can load .ply files directly
-            let scene = try SCNScene(url: url, options: nil)
+    var body: some View {
+        VStack {
+            if let scene = scene {
+                // If the scene loaded successfully, display it.
+                SceneView(
+                    scene: scene,
+                    options: [
+                        .allowsCameraControl, // Enables mouse/trackpad controls to rotate, pan, and zoom.
+                        .autoenablesDefaultLighting // Adds a generic light source to the scene.
+                    ]
+                )
+            } else {
+                // If the scene failed to load, show an error message.
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.black.opacity(0.2))
 
-            // Add a camera to the scene
-            let cameraNode = SCNNode()
-            cameraNode.camera = SCNCamera()
-            cameraNode.position = SCNVector3(x: 0, y: 0, z: 5) // Position the camera
-            scene.rootNode.addChildNode(cameraNode)
-
-            // Add lighting to the scene
-            let lightNode = SCNNode()
-            lightNode.light = SCNLight()
-            lightNode.light!.type = .omni
-            lightNode.position = SCNVector3(x: 10, y: 10, z: 10)
-            scene.rootNode.addChildNode(lightNode)
-
-            let ambientLightNode = SCNNode()
-            ambientLightNode.light = SCNLight()
-            ambientLightNode.light!.type = .ambient
-            ambientLightNode.light!.color = UIColor.darkGray
-            scene.rootNode.addChildNode(ambientLightNode)
-
-            return scene
-        } catch {
-            print("Failed to load scene: \(error)")
-            return nil
+                    VStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.yellow)
+                            .padding(.bottom, 8)
+                        Text("Failed to Load Model")
+                            .font(.headline)
+                        Text(modelURL.lastPathComponent)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
         }
+        .frame(minHeight: 300) // Ensure the view has a reasonable size.
     }
 }
 
-struct SceneKitView: UIViewRepresentable {
-    let scene: SCNScene?
+struct ThreeDPreviewView_Previews: PreviewProvider {
+    static var previews: some View {
+        // To make the preview work, we need a sample model file in our project.
+        // The Python stub points to 'placeholder_figurine.ply'. We'll try to find it in the bundle.
+        // Note: Previews run from a different context, so finding the project root is tricky.
+        // This preview might only work when running the app.
 
-    func makeUIView(context: Context) -> SCNView {
-        let scnView = SCNView()
-        scnView.allowsCameraControl = true
-        scnView.autoenablesDefaultLighting = true
-        scnView.backgroundColor = UIColor.lightGray
-        return scnView
-    }
+        // A mock URL for a non-existent file to test the failure case.
+        let failingURL = URL(fileURLWithPath: "/path/to/nonexistent.ply")
 
-    func updateUIView(_ uiView: SCNView, context: Context) {
-        uiView.scene = scene
+        // Let's create a dummy file for the success case preview
+        let successURL = FileManager.default.temporaryDirectory.appendingPathComponent("preview.usdz")
+        let scene = SCNScene()
+        scene.rootNode.addChildNode(SCNNode(geometry: SCNSphere(radius: 1.0)))
+        try? scene.write(to: successURL, options: nil, delegate: nil, progressHandler: nil)
+
+        return Group {
+            ThreeDPreviewView(modelURL: successURL)
+                .padding()
+                .previewLayout(.fixed(width: 400, height: 400))
+                .previewDisplayName("Success")
+
+            ThreeDPreviewView(modelURL: failingURL)
+                .padding()
+                .previewLayout(.fixed(width: 400, height: 400))
+                .previewDisplayName("Failure")
+        }
     }
 }

--- a/MacForge3D/Utils/ScreenshotGenerator.swift
+++ b/MacForge3D/Utils/ScreenshotGenerator.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// A utility to programmatically generate screenshots of SwiftUI views.
+@MainActor
+class ScreenshotGenerator {
+
+    /// Generates and saves screenshots for all specified views.
+    static func generateAll() async {
+        print("📸 Starting screenshot generation...")
+
+        // --- Generate main_workspace.png ---
+        print("› Generating 'main_workspace.png' from ContentView...")
+        await generateScreenshot(
+            for: ContentView(),
+            as: "main_workspace.png",
+            width: 1280,
+            height: 800
+        )
+
+        // --- Placeholder for text_to_3d.png ---
+        // Generating this screenshot requires getting the UI into a specific state
+        // after a model has been generated, which is complex to do programmatically
+        // without significant refactoring of the views.
+        // For now, we will skip this one and inform the user.
+        print("› Skipping 'text_to_3d.png'. This requires manual generation for now.")
+
+
+        print("✅ Screenshot generation process finished.")
+    }
+
+    /// Renders a given SwiftUI view and saves it as a PNG image.
+    ///
+    /// - Parameters:
+    ///   - view: The SwiftUI view to render.
+    ///   - filename: The name of the output PNG file.
+    ///   - width: The width of the output image.
+    ///   - height: The height of the output image.
+    private static func generateScreenshot<V: View>(for view: V, as filename: String, width: CGFloat, height: CGFloat) async {
+        let outputDirectory = URL(fileURLWithPath: "Documentation/screenshots", isDirectory: true)
+
+        // Ensure the directory exists
+        do {
+            try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        } catch {
+            print("❌ Failed to create screenshot directory: \(error)")
+            return
+        }
+
+        let url = outputDirectory.appendingPathComponent(filename)
+
+        // Use ImageRenderer to get a CGImage from the view.
+        let renderer = ImageRenderer(content: view.frame(width: width, height: height))
+        renderer.scale = 2.0 // Render at 2x for Retina quality
+
+        guard let cgImage = renderer.cgImage else {
+            print("❌ Failed to render CGImage for \(filename).")
+            return
+        }
+
+        // Use NSBitmapImageRep to convert the CGImage to PNG data.
+        let bitmap = NSBitmapImageRep(cgImage: cgImage)
+        bitmap.size = NSSize(width: width, height: height) // Set the bitmap size
+
+        guard let data = bitmap.representation(using: .png, properties: [:]) else {
+            print("❌ Failed to create PNG data for \(filename).")
+            return
+        }
+
+        // Write the data to the file.
+        do {
+            try data.write(to: url)
+            print("  ✅ Screenshot saved successfully to: \(url.path)")
+        } catch {
+            print("❌ Failed to write screenshot to disk for \(filename): \(error)")
+        }
+    }
+}

--- a/MacForge3D/app/MacForge3DApp.swift
+++ b/MacForge3D/app/MacForge3DApp.swift
@@ -1,1 +1,36 @@
+import SwiftUI
 
+@main
+struct MacForge3DApp: App {
+    // We capture the app's environment to decide whether to run normally or generate screenshots.
+    private let isGeneratingScreenshots: Bool
+
+    var body: some Scene {
+        WindowGroup {
+            // Only show the main window if not in screenshot mode.
+            if !isGeneratingScreenshots {
+                ContentView()
+                    .frame(minWidth: 800, minHeight: 600)
+            }
+        }
+        .windowStyle(DefaultWindowStyle())
+        .windowToolbarStyle(UnifiedCompactWindowToolbarStyle())
+        .windowTitle("MacForge3D")
+    }
+
+    init() {
+        // Check for the command-line argument.
+        self.isGeneratingScreenshots = CommandLine.arguments.contains("--generate-screenshots")
+
+        if isGeneratingScreenshots {
+            print("📸 Launching in screenshot generation mode...")
+            // Run the generator.
+            Task {
+                await ScreenshotGenerator.generateAll()
+                // Exit the app cleanly once screenshots are generated.
+                print("✅ Screenshot generation complete. Exiting.")
+                exit(0)
+            }
+        }
+    }
+}

--- a/MacForge3D/app/contentView.swift
+++ b/MacForge3D/app/contentView.swift
@@ -1,1 +1,78 @@
+import SwiftUI
 
+struct ContentView: View {
+    // State to keep track of the selected panel in the sidebar.
+    @State private var selection: Panel? = .textTo3D
+
+    // Enum to represent the different navigation destinations.
+    // This makes the code cleaner and less prone to errors.
+    enum Panel: String, CaseIterable, Identifiable {
+        case textTo3D = "Text to 3D"
+        case audioTo3D = "Audio to 3D"
+        case parametric = "Parametric"
+        case simulation = "Simulation"
+
+        var id: String { self.rawValue }
+
+        // Returns the appropriate system icon for each panel.
+        var iconName: String {
+            switch self {
+            case .textTo3D:
+                return "text.bubble.fill"
+            case .audioTo3D:
+                return "waveform.path.ecg"
+            case .parametric:
+                return "cube.transparent"
+            case .simulation:
+                return "flame.fill"
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            // Sidebar with a list of navigation links.
+            List(Panel.allCases, selection: $selection) { panel in
+                NavigationLink(value: panel) {
+                    Label(panel.rawValue, systemImage: panel.iconName)
+                }
+            }
+            .navigationSplitViewColumnWidth(220)
+            .listStyle(.sidebar)
+
+        } detail: {
+            // The detail view changes based on the sidebar selection.
+            // These are placeholders that will be replaced by actual views in later steps.
+            switch selection {
+            case .textTo3D:
+                TextTo3DView()
+            case .audioTo3D:
+                Text("Audio-to-3D View Placeholder")
+                    .font(.largeTitle)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .parametric:
+                Text("Parametric Shapes View Placeholder")
+                    .font(.largeTitle)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .simulation:
+                Text("Simulation View Placeholder")
+                    .font(.largeTitle)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .none:
+                // A view to show when no selection is made.
+                Text("Select a tool from the sidebar to begin.")
+                    .font(.largeTitle)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("MacForge3D")
+    }
+}
+
+// Preview provider for Xcode Previews
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/MacForge3D/core/AI/TextTo3D.swift
+++ b/MacForge3D/core/AI/TextTo3D.swift
@@ -1,59 +1,75 @@
 import Foundation
 import PythonKit
+import AppKit // To get the running application's path
 
-enum TextTo3DError: Error {
-    case pythonScriptNotFound
-    case pythonFunctionNotFound
-    case modelGenerationFailed(String)
-}
+class TextTo3DGenerator {
 
-class TextTo3D {
+    private static var isPythonInitialized = false
 
-    private var textTo3DPy: PythonObject?
+    private static func initializePython() {
+        guard !isPythonInitialized else { return }
 
-    init() {
-        do {
-            // Add the 'Python' directory to the Python path
-            let sys = try Python.import("sys")
-            let projectRoot = FileManager.default.currentDirectoryPath
-            let pythonPath = "\(projectRoot)/Python"
-            sys.path.append(pythonPath)
+        // Determine the project root directory to make relative paths work
+        // This is a simple approach for development builds run from Xcode.
+        // A packaged app would require a different approach (e.g., bundling the venv).
+        let projectRoot = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent() // /core/AI
+            .deletingLastPathComponent() // /core
+            .deletingLastPathComponent() // /MacForge3D
+            .path
 
-            // Import the python script
-            self.textTo3DPy = try Python.import("ai_models.text_to_3d")
-        } catch {
-            print("Failed to initialize Python environment: \(error)")
-            self.textTo3DPy = nil
-        }
-    }
+        // Set the Python library path. This is crucial for PythonKit to find the interpreter.
+        // We check for both Apple Silicon and Intel Homebrew installations.
+        let appleSiliconPath = "/opt/homebrew/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib"
+        let intelPath = "/usr/local/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib"
 
-    func generateModel(prompt: String, completion: @escaping (Result<String, TextTo3DError>) -> Void) {
-        guard let textTo3DModule = self.textTo3DPy else {
-            completion(.failure(.pythonScriptNotFound))
+        let pythonLibPath = FileManager.default.fileExists(atPath: appleSiliconPath) ? appleSiliconPath : intelPath
+
+        guard FileManager.default.fileExists(atPath: pythonLibPath) else {
+            print("FATAL ERROR: Could not find Python 3.11 library. Make sure it's installed via Homebrew.")
+            // In a real app, you'd want to show an alert to the user.
             return
         }
 
-        // Run the python function in a background thread to avoid blocking the UI
-        DispatchQueue.global(qos: .userInitiated).async {
-            do {
-                let generateFunc = textTo3DModule.generate_3d_model
-                let resultPath = try generateFunc(prompt).get()
+        PythonLibrary.useLibrary(at: pythonLibPath)
 
-                if let path = String(resultPath) {
-                    // Switch back to the main thread to return the result
-                    DispatchQueue.main.async {
-                        completion(.success(path))
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        completion(.failure(.modelGenerationFailed("Failed to convert result path to String")))
-                    }
-                }
+        let sys = Python.import("sys")
+
+        // Add the path to our Python scripts to Python's sys.path
+        let scriptsPath = URL(fileURLWithPath: projectRoot).appendingPathComponent("Python/ai_models").path
+        sys.path.append(scriptsPath)
+
+        print("✅ Python initialized successfully.")
+        print("🐍 Python version: \(sys.version)")
+        print("🐍 Python path: \(sys.path)")
+
+        isPythonInitialized = true
+    }
+
+    /// Asynchronously generates a 3D model from a text prompt by calling a Python script.
+    ///
+    /// - Parameter prompt: The text description of the model to generate.
+    /// - Returns: A `String` containing the path to the generated model file, or `nil` if an error occurred.
+    static func generate(prompt: String) async -> String? {
+        initializePython()
+
+        // Run the Python code on a background thread to avoid blocking the UI
+        return await Task.detached(priority: .userInitiated) {
+            do {
+                print("🐍 Importing 'text_to_3d' Python module...")
+                let textTo3DModule = Python.import("text_to_3d")
+                print("🐍 Calling 'generate_3d_model' function with prompt: '\(prompt)'")
+
+                let result = textTo3DModule.generate_3d_model(prompt)
+
+                // Convert the PythonObject result to a Swift String
+                let path = String(result)
+                print("✅ Python script executed successfully. Result: \(path ?? "nil")")
+                return path
             } catch {
-                DispatchQueue.main.async {
-                    completion(.failure(.modelGenerationFailed(error.localizedDescription)))
-                }
+                print("❌ Python script execution failed with error: \(error)")
+                return nil
             }
-        }
+        }.value
     }
 }

--- a/Python/ai_models/text_to_3d.py
+++ b/Python/ai_models/text_to_3d.py
@@ -1,23 +1,123 @@
+import torch
+from diffusers import ShapEPipeline
+from diffusers.utils import export_to_ply
+
 import os
+from datetime import datetime
+
+# --- Configuration ---
+# Directory to save the generated models. This path is relative to the project root.
+output_dir = "Examples/generated_models"
+# Hugging Face model name for the Shap-E model.
+model_name = "openai/shap-e"
+
+# --- Global Variables ---
+# We'll load the pipeline once and reuse it to save memory and time.
+pipe = None
+is_pipe_loaded = False
+device = None
+
+def initialize_pipeline():
+    """Initializes the Shap-E pipeline and moves it to the appropriate device."""
+    global pipe, is_pipe_loaded, device
+
+    if is_pipe_loaded:
+        return
+
+    # --- Setup device ---
+    # Check for Apple's Metal Performance Shaders (MPS) for GPU acceleration on Mac.
+    if torch.backends.mps.is_available():
+        device = torch.device("mps")
+        torch_dtype = torch.float16  # Use float16 for memory efficiency on MPS
+    elif torch.cuda.is_available():
+        device = torch.device("cuda")
+        torch_dtype = torch.float16
+    else:
+        device = torch.device("cpu")
+        torch_dtype = torch.float32  # CPU works better with float32
+
+    print(f"🐍 Using device: {device}")
+
+    # --- Load the pipeline ---
+    # This will download the model on the first run and cache it in ~/.cache/huggingface/hub.
+    print(f"🐍 Loading Shap-E pipeline from '{model_name}'...")
+    try:
+        pipe = ShapEPipeline.from_pretrained(model_name, torch_dtype=torch_dtype)
+        pipe = pipe.to(device)
+        print("✅ Pipeline loaded successfully.")
+        is_pipe_loaded = True
+    except Exception as e:
+        print(f"❌ Failed to load the Shap-E pipeline: {e}")
+        # This could be due to no internet connection, or an invalid model name.
+        pipe = None
+        is_pipe_loaded = False
 
 def generate_3d_model(prompt: str) -> str:
     """
-    This function simulates the generation of a 3D model from a text prompt.
-    In a real implementation, this function would:
-    1. Take the text prompt as input.
-    2. Use a 3D diffusion model (like Text2Room) to generate a 3D mesh.
-    3. Save the mesh to a file.
-    4. Return the path to the file.
-
-    For now, it returns the path to a placeholder .ply file.
+    Generates a 3D model from a text prompt using the Shap-E model.
+    If the model generation fails, it returns a string containing an error message.
     """
-    # The path is relative to the root of the project.
-    placeholder_path = "MacForge3D/Ressource/Models/placeholder_figurine.ply"
+    # Initialize the pipeline on the first call.
+    if not is_pipe_loaded:
+        initialize_pipeline()
 
-    # In a real scenario, we would generate a unique filename for each model.
-    # For this scaffolding, we just return the path to the single placeholder.
+    if not pipe:
+        return "Error: Shap-E pipeline is not available. Check logs for details."
 
-    print(f"Simulating 3D model generation for prompt: '{prompt}'")
-    print(f"Returning path to placeholder model: '{placeholder_path}'")
+    print(f"🐍 Generating 3D model for prompt: '{prompt}'...")
 
-    return placeholder_path
+    # --- Create output directory if it doesn't exist ---
+    os.makedirs(output_dir, exist_ok=True)
+
+    # --- Generate a unique filename to avoid overwriting ---
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # Sanitize the prompt to create a valid, short filename.
+    sanitized_prompt = "".join(c for c in prompt if c.isalnum() or c in (' ', '_')).rstrip()
+    sanitized_prompt = sanitized_prompt.replace(' ', '_')[:30]
+    filename = f"{timestamp}_{sanitized_prompt}.ply"
+    output_path = os.path.join(output_dir, filename)
+
+    # --- Run the model inference ---
+    try:
+        # The guidance_scale and num_inference_steps are key parameters to tune quality vs. speed.
+        images = pipe(
+            prompt,
+            guidance_scale=15.0,
+            num_inference_steps=64,  # Higher steps can improve quality but take longer.
+            frame_size=256,        # The size of the latent images, affects detail.
+            output_type="mesh"
+        ).images
+
+        # The pipeline returns a list of meshes; for Shap-E, it's typically one.
+        if not images:
+            raise ValueError("Model did not return any images/meshes.")
+
+        mesh = images[0]
+
+        # --- Save the generated mesh to a .ply file ---
+        # We use the export_to_ply utility function from the diffusers library.
+        export_to_ply(mesh, output_path)
+
+        print(f"✅ Model saved successfully to: {output_path}")
+        return output_path
+
+    except Exception as e:
+        print(f"❌ An error occurred during model generation: {e}")
+        # Return the error message to be displayed in the UI.
+        return f"Error: {e}"
+
+if __name__ == '__main__':
+    # This block allows for testing the script directly from the command line.
+    # Example: python Python/ai_models/text_to_3d.py
+    print("\n--- Running standalone test of text_to_3d.py ---")
+    test_prompt = "a robot wearing a cowboy hat"
+    print(f"Test prompt: '{test_prompt}'")
+
+    path = generate_3d_model(test_prompt)
+
+    if path and "Error" not in path:
+        print(f"\n✅ Test successful! Model saved at: {path}")
+        # Provide instructions for viewing the model
+        print("You can view the generated .ply file using a 3D viewer like MeshLab or Blender.")
+    else:
+        print(f"\n❌ Test failed. Reason: {path}")

--- a/Scripts/setup_project.sh
+++ b/Scripts/setup_project.sh
@@ -1,1 +1,92 @@
+#!/bin/bash
+#
+# MacForge3D Project Setup Script
+#
+# This script automates the setup of the development environment for the MacForge3D application.
+# It installs system dependencies using Homebrew, sets up a Python virtual environment,
+# and installs the required Python packages.
+#
+# Prerequisites:
+# - macOS
+# - Xcode Command Line Tools (can be installed with `xcode-select --install`)
 
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "🚀 Starting MacForge3D project setup..."
+
+# --- Check for and install Xcode Command Line Tools ---
+if ! xcode-select -p &>/dev/null; then
+  echo "› Xcode Command Line Tools not found. Please install them by running 'xcode-select --install' in your terminal and re-run this script."
+  exit 1
+fi
+echo "✅ Xcode Command Line Tools found."
+
+# --- Check for and install Homebrew ---
+if ! command -v brew &>/dev/null; then
+  echo "› Homebrew not found. Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Add Homebrew to PATH for this script's session
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+else
+  echo "› Homebrew is already installed. Updating..."
+  brew update
+fi
+echo "✅ Homebrew setup complete."
+
+# --- Install system dependencies ---
+echo "› Installing system dependencies (Python 3.11, Git LFS)..."
+brew install python@3.11 git-lfs
+echo "✅ System dependencies installed."
+
+# --- Configure Python Virtual Environment ---
+PYTHON_VERSION="3.11"
+VENV_DIR="python_env"
+
+if [ -d "$VENV_DIR" ]; then
+  echo "› Python virtual environment '$VENV_DIR' already exists. Re-creating it..."
+  rm -rf "$VENV_DIR"
+fi
+
+echo "› Creating Python $PYTHON_VERSION virtual environment in './$VENV_DIR'..."
+# On Apple Silicon, Homebrew installs to /opt/homebrew. On Intel, /usr/local.
+# This logic handles both cases.
+if [ -f "/opt/homebrew/opt/python@$PYTHON_VERSION/bin/python$PYTHON_VERSION" ]; then
+    "/opt/homebrew/opt/python@$PYTHON_VERSION/bin/python$PYTHON_VERSION" -m venv "$VENV_DIR"
+else
+    "/usr/local/opt/python@$PYTHON_VERSION/bin/python$PYTHON_VERSION" -m venv "$VENV_DIR"
+fi
+echo "✅ Virtual environment created."
+
+# --- Activate virtual environment and install Python packages ---
+echo "› Activating virtual environment and installing Python packages..."
+source "$VENV_DIR/bin/activate"
+
+# Upgrade pip
+pip install --upgrade pip
+
+# Install required packages for AI and 3D processing
+# torch, transformers, diffusers for AI models
+# Pillow for image handling
+# numpy for numerical operations
+# trimesh for 3D mesh processing (useful for later)
+pip install torch transformers diffusers accelerate Pillow numpy trimesh safetensors
+# Note: PythonKit is a Swift framework, not a pip package. It's already in the project.
+
+echo "✅ Python packages installed."
+deactivate
+echo "› Virtual environment deactivated."
+
+
+# --- Configure Git LFS ---
+echo "› Setting up Git LFS..."
+git lfs install
+# The following command would be needed to track large files,
+# but we will let the developer decide which files to track.
+# Example: git lfs track "*.ply"
+# We will just ensure it's installed for the repo.
+echo "✅ Git LFS configured."
+
+echo "🎉 MacForge3D setup complete!"
+echo "To activate the Python environment for development, run: source $VENV_DIR/bin/activate"
+echo "You can now open the MacForge3D.xcodeproj file in Xcode and build the project."


### PR DESCRIPTION
I've taken the MacForge3D project from a skeleton to a functional application with a core Text-to-3D feature, creating the UI, the AI backend, and the necessary tooling for development.

Key Features & Improvements:
- **Application Structure:** Implemented the main application window and UI using a modern SwiftUI `NavigationSplitView` for navigation.
- **Text-to-3D UI:** Created a dedicated view for the Text-to-3D feature with input fields and a generation button.
- **3D Viewport:** Added a `SceneKit`-based 3D preview component to visualize the generated models directly in the app.
- **AI Backend:** Replaced the Python stub with a real implementation using the `openai/shap-e` model via the `diffusers` library. The script now handles device selection (MPS/CUDA/CPU) and saves generated models.
- **Swift/Python Integration:** Refactored the Swift-Python bridge to use modern `async/await` with `PythonKit`, making the interaction clean and non-blocking.
- **Setup Script:** Created a comprehensive `setup_project.sh` script to automate the setup of the development environment, including Homebrew, Python, and all required packages.
- **Screenshot Utility:** Added a utility to programmatically generate screenshots of the application's UI for documentation purposes, triggered by a `--generate-screenshots` launch argument.

This initial implementation lays a solid foundation for future development and delivers the first core feature of the application.