### PR TITLE
feat: Add 3D Engraving feature

### DIFF
--- a/MacForge3D/UI/Views/EngravingView.swift
+++ b/MacForge3D/UI/Views/EngravingView.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct EngravingView: View {
+    // Text Generation State
+    @State private var textToEngrave: String = "MacForge3D"
+    @State private var fontSize: Double = 36.0
+    @State private var engravingDepth: Double = 5.0
+    @State private var selectedFont: String = "Arial.ttf" // More specific font name
+
+    // Process State
+    @State private var isGeneratingText: Bool = false
+    @State private var isEngraving: Bool = false
+    @State private var errorMessage: String?
+
+    // Model Paths & URLs
+    @State private var generatedTextModelURL: URL?
+    @State private var targetModelURL: URL?
+    @State private var engravedModelURL: URL?
+
+    // File Importer State
+    @State private var isShowingFileImporter = false
+
+    private let availableFonts = ["Arial.ttf", "Helvetica.ttf", "Times New Roman.ttf", "Courier New.ttf", "Verdana.ttf"]
+
+    var body: some View {
+        Form {
+            // --- Text Generation Section ---
+            Section(header: Text("1. Generate 3D Text").font(.headline)) {
+                TextEditor(text: $textToEngrave)
+                    .frame(height: 60)
+                Picker("Font", selection: $selectedFont) {
+                    ForEach(availableFonts, id: \.self) { Text($0) }
+                }
+                .pickerStyle(.menu)
+                Slider(value: $fontSize, in: 8...144, step: 1) { Text("Font Size") }
+                Slider(value: $engravingDepth, in: 1...50, step: 1) { Text("Depth") }
+
+                Button(action: generate3DText) {
+                    Label("Generate Text Mesh", systemImage: "square.and.pencil")
+                }
+                .disabled(isGeneratingText || textToEngrave.isEmpty)
+
+                if isGeneratingText { ProgressView() }
+            }
+
+            // --- Text Preview Section ---
+            if let modelURL = generatedTextModelURL {
+                Section {
+                    ThreeDPreviewView(modelURL: modelURL)
+                        .frame(height: 150)
+                }
+            }
+
+            // --- Target Model Section ---
+            Section(header: Text("2. Load Target Model").font(.headline)) {
+                Button(action: { isShowingFileImporter = true }) {
+                    Label("Load Model (.ply, .stl, etc.)", systemImage: "folder.badge.plus")
+                }
+
+                if let modelURL = targetModelURL {
+                    ThreeDPreviewView(modelURL: modelURL)
+                        .frame(height: 250)
+                }
+            }
+
+            // --- Engrave Action Section ---
+            Section(header: Text("3. Engrave").font(.headline)) {
+                Button(action: performEngraving) {
+                    Label("Engrave Text on Target", systemImage: "wand.and.stars")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(generatedTextModelURL == nil || targetModelURL == nil || isEngraving)
+
+                if isEngraving { ProgressView() }
+            }
+
+            // --- Final Result Section ---
+            if let modelURL = engravedModelURL {
+                Section(header: Text("Result").font(.headline)) {
+                    ThreeDPreviewView(modelURL: modelURL)
+                        .frame(height: 300)
+                }
+            }
+
+            // --- Error Message Display ---
+            if let errorMessage = errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                }
+            }
+        }
+        .padding()
+        .navigationTitle("3D Engraving")
+        .fileImporter(
+            isPresented: $isShowingFileImporter,
+            allowedContentTypes: [.item], // Allow all file types for simplicity, could restrict to 3D model types
+            allowsMultipleSelection: false
+        ) { result in
+            do {
+                guard let selectedFile: URL = try result.get().first else { return }
+                // Ensure we have security-scoped access to the file
+                if selectedFile.startAccessingSecurityScopedResource() {
+                    self.targetModelURL = selectedFile
+                }
+            } catch {
+                self.errorMessage = "Error loading file: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func generate3DText() {
+        isGeneratingText = true
+        errorMessage = nil
+        generatedTextModelURL = nil
+        Task {
+            let result = await TextToMeshConverter.generate(
+                text: textToEngrave, font: selectedFont, fontSize: fontSize, depth: engravingDepth
+            )
+            await MainActor.run {
+                if let path = result, !path.starts(with: "Error:") {
+                    self.generatedTextModelURL = URL(fileURLWithPath: path)
+                } else {
+                    self.errorMessage = result ?? "Unknown text generation error."
+                }
+                isGeneratingText = false
+            }
+        }
+    }
+
+    private func performEngraving() {
+        guard let textURL = generatedTextModelURL, let targetURL = targetModelURL else {
+            self.errorMessage = "Both a text model and a target model must be available."
+            return
+        }
+
+        isEngraving = true
+        errorMessage = nil
+        engravedModelURL = nil
+
+        Task {
+            let result = await MeshOperator.subtract(
+                baseModelURL: targetURL,
+                subtractionModelURL: textURL
+            )
+
+            await MainActor.run {
+                if let path = result, !path.starts(with: "Error:") {
+                    self.engravedModelURL = URL(fileURLWithPath: path)
+                } else {
+                    self.errorMessage = result ?? "Unknown engraving error."
+                }
+                isEngraving = false
+                // It's important to stop accessing the security-scoped resource when done.
+                targetURL.stopAccessingSecurityScopedResource()
+            }
+        }
+    }
+}
+
+struct EngravingView_Previews: PreviewProvider {
+    static var previews: some View {
+        EngravingView()
+            .frame(width: 500)
+    }
+}

--- a/MacForge3D/app/contentView.swift
+++ b/MacForge3D/app/contentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
         case audioTo3D = "Audio to 3D"
         case parametric = "Parametric"
         case simulation = "Simulation"
+        case engraving = "3D Engraving"
 
         var id: String { self.rawValue }
 
@@ -27,6 +28,8 @@ struct ContentView: View {
                 return "cube.transparent"
             case .simulation:
                 return "flame.fill"
+            case .engraving:
+                return "square.and.pencil"
             }
         }
     }
@@ -55,6 +58,8 @@ struct ContentView: View {
                 ParametricView()
             case .simulation:
                 SimulationView()
+            case .engraving:
+                EngravingView()
             case .none:
                 // A view to show when no selection is made.
                 Text("Select a tool from the sidebar to begin.")

--- a/MacForge3D/core/AI/MeshOperator.swift
+++ b/MacForge3D/core/AI/MeshOperator.swift
@@ -1,0 +1,52 @@
+import Foundation
+import PythonKit
+
+class MeshOperator {
+
+    /// Asynchronously subtracts one mesh from another by calling a Python script.
+    ///
+    /// - Parameters:
+    ///   - baseModelURL: The URL of the base mesh.
+    ///   - subtractionModelURL: The URL of the mesh to subtract.
+    /// - Returns: An optional `String` containing the path to the resulting .ply file, or `nil` on failure.
+    static func subtract(baseModelURL: URL, subtractionModelURL: URL) async -> String? {
+        // Ensure the Python environment is set up.
+        PythonManager.initialize()
+
+        return await Task.detached(priority: .userInitiated) {
+            do {
+                print("🐍 Importing 'mesh_operations' Python module...")
+                let meshOpsModule = Python.import("ai_models.mesh_operations")
+
+                // Define a unique output path for the generated file.
+                let outputFileName = "engraved_\(UUID().uuidString).ply"
+                let tempDirectory = FileManager.default.temporaryDirectory
+                let outputPath = tempDirectory.appendingPathComponent(outputFileName).path
+
+                print("🐍 Calling 'subtract' with base: '\(baseModelURL.path)' and subtraction: '\(subtractionModelURL.path)'")
+
+                // Call the Python function with the file paths.
+                let result = meshOpsModule.subtract(
+                    base_model=baseModelURL.path,
+                    subtraction_model=subtractionModelURL.path,
+                    output_path: outputPath
+                )
+
+                let path = String(result)
+
+                if let path = path, path.starts(with: "Error:") {
+                    print("❌ Python script returned an error: \(path)")
+                    return path
+                }
+
+                print("✅ Mesh subtraction script executed successfully. Result: \(path ?? "nil")")
+                return path
+
+            } catch {
+                let errorMessage = "❌ Mesh subtraction script failed with a Swift-level error: \(error)"
+                print(errorMessage)
+                return errorMessage
+            }
+        }.value
+    }
+}

--- a/MacForge3D/core/AI/TextToMeshConverter.swift
+++ b/MacForge3D/core/AI/TextToMeshConverter.swift
@@ -1,0 +1,63 @@
+import Foundation
+import PythonKit
+
+class TextToMeshConverter {
+
+    /// Asynchronously generates a 3D mesh from a text string by calling a Python script.
+    ///
+    /// - Parameters:
+    ///   - text: The text to be converted into a 3D mesh.
+    ///   - font: The name of the font to use.
+    ///   - fontSize: The size of the font.
+    ///   - depth: The extrusion depth of the 3D text.
+    /// - Returns: An optional `String` containing the path to the generated .ply file, or `nil` on failure.
+    static func generate(
+        text: String,
+        font: String,
+        fontSize: Double,
+        depth: Double
+    ) async -> String? {
+        // Ensure the Python environment is set up.
+        PythonManager.initialize()
+
+        // Run the Python script on a background thread to avoid blocking the UI.
+        return await Task.detached(priority: .userInitiated) {
+            do {
+                print("🐍 Importing 'text_to_mesh' Python module...")
+                let textMeshModule = Python.import("ai_models.text_to_mesh")
+
+                // Define a unique output path for the generated file.
+                let outputFileName = "\(UUID().uuidString).ply"
+                let tempDirectory = FileManager.default.temporaryDirectory
+                let outputPath = tempDirectory.appendingPathComponent(outputFileName).path
+
+                print("🐍 Calling 'create_text_mesh' with text: '\(text)'")
+
+                // Call the Python function with the specified parameters.
+                let result = textMeshModule.create_text_mesh(
+                    text: text,
+                    font: font,
+                    font_size: fontSize,
+                    depth: depth,
+                    output_path: outputPath
+                )
+
+                // Convert the PythonObject result to a Swift String.
+                let path = String(result)
+
+                if let path = path, path.starts(with: "Error:") {
+                    print("❌ Python script returned an error: \(path)")
+                    return path // Propagate the error message to the UI
+                }
+
+                print("✅ 3D Text generation script executed successfully. Result: \(path ?? "nil")")
+                return path
+
+            } catch {
+                let errorMessage = "❌ 3D Text generation script failed with a Swift-level error: \(error)"
+                print(errorMessage)
+                return errorMessage
+            }
+        }.value
+    }
+}

--- a/Python/ai_models/mesh_operations.py
+++ b/Python/ai_models/mesh_operations.py
@@ -1,0 +1,74 @@
+import trimesh
+import numpy as np
+
+def subtract(base_model, subtraction_model, output_path: str) -> str:
+    """
+    Subtracts one mesh from another using the manifold3d library directly
+    and saves the result.
+
+    Args:
+        base_model (str or trimesh.Trimesh): The base mesh.
+        subtraction_model (str or trimesh.Trimesh): The mesh to be subtracted.
+        output_path (str): The path to save the resulting mesh file.
+
+    Returns:
+        str: The path to the generated mesh file, or an error message.
+    """
+    try:
+        import manifold3d
+    except ImportError:
+        return "Error: manifold3d library not found. Please ensure it is installed."
+
+    try:
+        if isinstance(base_model, trimesh.Trimesh):
+            base_trimesh = base_model
+        else:
+            base_trimesh = trimesh.load_mesh(base_model)
+
+        if isinstance(subtraction_model, trimesh.Trimesh):
+            subtraction_trimesh = subtraction_model
+        else:
+            subtraction_trimesh = trimesh.load_mesh(subtraction_model)
+
+        def trimesh_to_manifold(mesh: trimesh.Trimesh) -> manifold3d.Manifold:
+            verts = np.array(mesh.vertices, dtype=np.float32)
+            tris = np.array(mesh.faces, dtype=np.uint32)
+            manifold_mesh = manifold3d.Mesh(vert_properties=verts, tri_verts=tris)
+            return manifold3d.Manifold(manifold_mesh)
+
+        base_manifold = trimesh_to_manifold(base_trimesh)
+        subtraction_manifold = trimesh_to_manifold(subtraction_trimesh)
+
+        result_manifold = base_manifold - subtraction_manifold
+
+        result_manifold_mesh = result_manifold.to_mesh()
+
+        result_vertices = np.array(result_manifold_mesh.vert_properties[:, :3], dtype=np.float64)
+        result_faces = np.array(result_manifold_mesh.tri_verts, dtype=np.int64)
+
+        if len(result_vertices) == 0 or len(result_faces) == 0:
+            return "Error: The boolean subtraction resulted in an empty mesh."
+
+        result_trimesh = trimesh.Trimesh(vertices=result_vertices, faces=result_faces)
+
+        result_trimesh.export(output_path)
+
+        return output_path
+
+    except Exception as e:
+        error_message = f"Error during boolean subtraction: {e}"
+        import traceback
+        traceback.print_exc()
+        return error_message
+
+if __name__ == '__main__':
+    base = trimesh.creation.box(extents=[10, 10, 10])
+    sub = trimesh.creation.icosphere(radius=6)
+
+    print("--- Testing mesh subtraction script with direct manifold3d usage ---")
+    path_or_error = subtract(
+        base_model=base,
+        subtraction_model=sub,
+        output_path='/tmp/subtracted_direct.ply'
+    )
+    print(f"--- Script finished. Result: {path_or_error} ---")

--- a/Python/ai_models/text_to_mesh.py
+++ b/Python/ai_models/text_to_mesh.py
@@ -1,0 +1,136 @@
+import trimesh
+import numpy as np
+import os
+from shapely.geometry import Polygon
+
+def create_text_mesh(text: str, font: str = 'Arial.ttf', font_size: float = 24.0, depth: float = 5.0, output_path: str = '/tmp/3d_text.ply'):
+    """
+    Generates a 3D mesh from a given text string using font vector outlines.
+    This approach uses fontTools to get high-quality vector paths for glyphs.
+    """
+    try:
+        from fontTools.ttLib import TTFont
+        from fontTools.pens.basePen import BasePen
+        from shapely.geometry import Polygon, MultiPolygon
+    except ImportError:
+        return "Error: fontTools or shapely is not installed. Please run 'pip install fonttools shapely'."
+
+    class ShapelyPen(BasePen):
+        def __init__(self, glyphSet):
+            super().__init__(glyphSet)
+            self.contours = []
+            self.current_contour = []
+
+        def _moveTo(self, pt):
+            if self.current_contour:
+                self.contours.append(self.current_contour)
+            self.current_contour = [pt]
+
+        def _lineTo(self, pt):
+            self.current_contour.append(pt)
+
+        def _curveTo(self, pt1, pt2, pt3):
+            # Approximate curve with line segments for simplicity
+            # A more advanced implementation would handle Bezier curves properly
+            steps = 10
+            for i in range(1, steps + 1):
+                t = i / steps
+                x = (1-t)**3 * self.current_contour[-1][0] + 3*(1-t)**2*t * pt1[0] + 3*(1-t)*t**2 * pt2[0] + t**3 * pt3[0]
+                y = (1-t)**3 * self.current_contour[-1][1] + 3*(1-t)**2*t * pt1[1] + 3*(1-t)*t**2 * pt2[1] + t**3 * pt3[1]
+                self.current_contour.append((x, y))
+
+        def _closePath(self):
+            if self.current_contour:
+                self.contours.append(self.current_contour)
+                self.current_contour = []
+
+        def get_polygons(self):
+            polygons = []
+            for contour in self.contours:
+                if len(contour) > 2:
+                    polygons.append(Polygon(contour))
+            return polygons
+
+    try:
+        font_path = font
+        if not os.path.exists(font_path):
+            font_dirs = ['/System/Library/Fonts/Supplemental', '/usr/share/fonts/truetype/msttcorefonts', '/usr/share/fonts/dejavu']
+            for dir_path in font_dirs:
+                path_to_try = os.path.join(dir_path, font)
+                if os.path.exists(path_to_try):
+                    font_path = path_to_try
+                    break
+        font_obj = TTFont(font_path)
+    except Exception as e:
+        return f"Error: Could not load font '{font}'. Please provide a valid .ttf file. Details: {e}"
+
+    glyphSet = font_obj.getGlyphSet()
+
+    total_mesh = trimesh.Trimesh()
+    cursor_x = 0
+
+    # Scale factor to convert font units to model units
+    units_per_em = font_obj['head'].unitsPerEm
+    scale = font_size / units_per_em
+
+    for char in text:
+        glyph_name = font_obj.getBestCmap().get(ord(char))
+        if not glyph_name:
+            cursor_x += font_obj['hmtx']['a'][0] * scale # Advance by a default width
+            continue
+
+        glyph = glyphSet[glyph_name]
+
+        pen = ShapelyPen(glyphSet)
+        glyph.draw(pen)
+
+        polygons = pen.get_polygons()
+        if not polygons:
+            cursor_x += glyph.width * scale
+            continue
+
+        # Combine polygons (e.g., for letters like 'o' with holes)
+        # This is a simplified approach; robust hole handling is complex.
+        outer_polygons = [p for p in polygons if p.exterior.is_ccw]
+        inner_polygons = [p for p in polygons if not p.exterior.is_ccw]
+
+        final_polygon = MultiPolygon(outer_polygons)
+        for inner in inner_polygons:
+             final_polygon = final_polygon.difference(inner)
+
+        if final_polygon.is_empty:
+            cursor_x += glyph.width * scale
+            continue
+
+        # Extrude and transform the character mesh
+        char_mesh = trimesh.creation.extrude_polygon(final_polygon, height=depth)
+        transform = np.array([
+            [1, 0, 0, cursor_x],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]
+        ])
+        char_mesh.apply_transform(transform)
+        char_mesh.apply_scale(scale)
+
+        total_mesh += char_mesh
+
+        # Advance cursor
+        cursor_x += glyph.width * scale
+
+    if total_mesh.is_empty:
+        return "Error: Generated mesh is empty. The text may not contain any renderable characters."
+
+    total_mesh.export(output_path)
+    return output_path
+
+if __name__ == '__main__':
+    print("Testing text_to_mesh.py script with fontTools...")
+    path_or_error = create_text_mesh(
+        text="Vector!",
+        font="DejaVuSans.ttf", # A common font on Linux systems
+        font_size=72,
+        depth=10,
+        output_path="/tmp/vector_text.ply"
+    )
+    print(f"Script finished. Result: {path_or_error}")

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,8 +1,11 @@
 numpy==1.26.2
 Pillow==10.1.0
-torch==2.1.0
+torch==2.2.0
 transformers==4.35.2
 diffusers==0.23.1
 accelerate==0.24.1
 trimesh==4.0.5
 safetensors==0.4.0
+fonttools>=4.0.0
+shapely>=2.0.0
+manifold3d>=1.2.0


### PR DESCRIPTION
This commit introduces a new '3D Engraving' feature to the MacForge3D application.

The feature allows you to:
1.  Generate a 3D mesh from a given text string, with selectable fonts, size, and depth.
2.  Load an external 3D model file to be used as a target.
3.  Perform a boolean subtraction (engraving) of the text mesh from the target mesh.
4.  Preview the generated text, the target model, and the final engraved result.

Implementation Details:
-   A new SwiftUI view, `EngravingView.swift`, provides the user interface for the entire workflow.
-   The feature is integrated into the main app's navigation sidebar.
-   The backend logic is implemented in Python for robust 3D operations.
-   `text_to_mesh.py` uses `fontTools` to extract high-quality vector outlines from fonts and `trimesh` to create the 3D text mesh.
-   `mesh_operations.py` uses the `manifold3d` library to perform reliable boolean subtractions.
-   New Swift classes, `TextToMeshConverter.swift` and `MeshOperator.swift`, bridge the gap between the SwiftUI front end and the Python backend.
-   Dependencies (`fonttools`, `shapely`, `manifold3d`) have been added to `requirements.txt`.