### PR TITLE
feat: Add Image-to-3D generation feature

### DIFF
--- a/MacForge3D/UI/Views/ImageTo3DView.swift
+++ b/MacForge3D/UI/Views/ImageTo3DView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ImageTo3DView: View {
+    // State for the path of the selected image.
+    @State private var selectedImagePath: String?
+
+    // State for the NSImage to display a preview.
+    @State private var selectedImage: NSImage?
+
+    // State for the selected model color.
+    @State private var modelColor: Color = .blue
+
+    // State to track the generation process.
+    @State private var isGenerating: Bool = false
+
+    // State to hold the path of the generated model.
+    @State private var generatedModelPath: String?
+
+    // State to show alerts to the user.
+    @State private var showAlert: Bool = false
+    @State private var alertMessage: String = ""
+
+    var body: some View {
+        Form {
+            Section(header: Text("Input Image").font(.headline)) {
+                VStack(alignment: .center, spacing: 16) {
+                    if let image = selectedImage {
+                        Image(nsImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 250)
+                            .cornerRadius(10)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color.gray.opacity(0.4), lineWidth: 1)
+                            )
+                    } else {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(NSColor.windowBackgroundColor))
+                                .frame(height: 250)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [10]))
+                                        .foregroundColor(.gray.opacity(0.5))
+                                )
+
+                            Text("Select an image to begin")
+                                .font(.title2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    Button(action: selectImage) {
+                        HStack {
+                            Image(systemName: "photo.on.rectangle.angled")
+                            Text(selectedImage == nil ? "Choose Image..." : "Change Image...")
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                .padding(.vertical)
+            }
+
+            Section(header: Text("Customization").font(.headline)) {
+                ColorPicker("Model Color", selection: $modelColor)
+            }
+
+            // Generate Button
+            HStack {
+                Spacer()
+                Button(action: triggerGeneration) {
+                    HStack {
+                        Image(systemName: "sparkles")
+                        Text("Generate Model")
+                    }
+                    .font(.title3)
+                }
+                .disabled(selectedImagePath == nil || isGenerating)
+                .controlSize(.large)
+                Spacer()
+            }
+            .padding()
+
+
+            if isGenerating {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
+                    Text("Generating model...")
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+                .padding()
+            }
+
+            if let modelPath = generatedModelPath {
+                let modelURL = URL(fileURLWithPath: modelPath)
+
+                Section(header: Text("Generated Model Preview").font(.headline)) {
+                    ThreeDPreviewView(modelURL: modelURL, modelColor: modelColor)
+                        .frame(height: 350)
+                        .background(Color(NSColor.windowBackgroundColor))
+                        .cornerRadius(10)
+                }
+            }
+        }
+        .padding()
+        .navigationTitle("Image to 3D")
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text("Error"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    private func selectImage() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        // Allow common image file types
+        panel.allowedContentTypes = [UTType.png, UTType.jpeg, UTType.bmp, UTType.tiff]
+
+        if panel.runModal() == .OK {
+            if let url = panel.url {
+                self.selectedImagePath = url.path
+                self.selectedImage = NSImage(contentsOf: url)
+                // Reset previous generation
+                self.generatedModelPath = nil
+            }
+        }
+    }
+
+    private func triggerGeneration() {
+        guard let imagePath = selectedImagePath else {
+            alertMessage = "Please select an image first."
+            showAlert = true
+            return
+        }
+
+        isGenerating = true
+        generatedModelPath = nil
+
+        Task {
+            print("Starting generation for image: \(imagePath)")
+            // We need to create ImageTo3DGenerator first.
+            // For now, let's assume it exists.
+            let result = await ImageTo3DGenerator.generate(imagePath: imagePath)
+
+            await MainActor.run {
+                if let path = result, !path.starts(with: "Error:") {
+                    self.generatedModelPath = path
+                } else {
+                    self.alertMessage = result ?? "An unknown error occurred during generation."
+                    self.showAlert = true
+                }
+                self.isGenerating = false
+            }
+        }
+    }
+}
+
+struct ImageTo3DView_Previews: PreviewProvider {
+    static var previews: some View {
+        ImageTo3DView()
+            .frame(width: 500)
+    }
+}

--- a/MacForge3D/app/contentView.swift
+++ b/MacForge3D/app/contentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     enum Panel: String, CaseIterable, Identifiable {
         case figurineGenerator = "Figurine Generator"
         case textTo3D = "Text to 3D"
+        case imageTo3D = "Image to 3D"
         case audioTo3D = "Audio to 3D"
         case parametric = "Parametric"
         case simulation = "Simulation"
@@ -22,6 +23,8 @@ struct ContentView: View {
                 return "person.crop.square.fill"
             case .textTo3D:
                 return "text.bubble.fill"
+            case .imageTo3D:
+                return "photo.fill"
             case .audioTo3D:
                 return "waveform.path.ecg"
             case .parametric:
@@ -52,6 +55,8 @@ struct ContentView: View {
                 FigurineGeneratorView()
             case .textTo3D:
                 TextTo3DView()
+            case .imageTo3D:
+                ImageTo3DView()
             case .audioTo3D:
                 AudioTo3DView()
             case .parametric:

--- a/MacForge3D/core/AI/ImageTo3D.swift
+++ b/MacForge3D/core/AI/ImageTo3D.swift
@@ -1,0 +1,33 @@
+import Foundation
+import PythonKit
+
+class ImageTo3DGenerator {
+
+    /// Asynchronously generates a 3D model from an image file by calling a Python script.
+    ///
+    /// - Parameter imagePath: The file system path to the input image.
+    /// - Returns: A `String` containing the path to the generated model file, or `nil` if an error occurred.
+    static func generate(imagePath: String) async -> String? {
+        // Ensure Python is set up before calling the script.
+        PythonManager.initialize()
+
+        // Run the Python code on a background thread to avoid blocking the UI
+        return await Task.detached(priority: .userInitiated) {
+            do {
+                print("🐍 Importing 'image_to_3d' Python module...")
+                let imageTo3DModule = Python.import("image_to_3d")
+                print("🐍 Calling 'generate_3d_model_from_image' function with path: '\(imagePath)'")
+
+                let result = imageTo3DModule.generate_3d_model_from_image(imagePath)
+
+                // Convert the PythonObject result to a Swift String
+                let path = String(result)
+                print("✅ Python script executed successfully. Result: \(path ?? "nil")")
+                return path
+            } catch {
+                print("❌ Python script execution failed with error: \(error)")
+                return "Error: Python script execution failed. See console for details."
+            }
+        }.value
+    }
+}

--- a/Python/ai_models/image_to_3d.py
+++ b/Python/ai_models/image_to_3d.py
@@ -1,0 +1,145 @@
+import torch
+from diffusers import ShapEImg2ImgPipeline
+from diffusers.utils import export_to_ply, load_image
+
+import os
+from datetime import datetime
+from PIL import Image
+
+# --- Configuration ---
+# Hugging Face model name for the Shap-E image-to-image model.
+model_name = "openai/shap-e-img2img"
+
+# --- Global Variables ---
+# We'll load the pipeline once and reuse it to save memory and time.
+pipe = None
+is_pipe_loaded = False
+device = None
+
+def initialize_pipeline():
+    """Initializes the Shap-E pipeline and moves it to the appropriate device."""
+    global pipe, is_pipe_loaded, device
+
+    if is_pipe_loaded:
+        return
+
+    # --- Setup device ---
+    # Check for Apple's Metal Performance Shaders (MPS) for GPU acceleration on Mac.
+    if torch.backends.mps.is_available():
+        device = torch.device("mps")
+        torch_dtype = torch.float16  # Use float16 for memory efficiency on MPS
+    elif torch.cuda.is_available():
+        device = torch.device("cuda")
+        torch_dtype = torch.float16
+    else:
+        device = torch.device("cpu")
+        torch_dtype = torch.float32  # CPU works better with float32
+
+    print(f"🐍 Using device: {device}")
+
+    # --- Load the pipeline ---
+    print(f"🐍 Loading Shap-E Img2Img pipeline from '{model_name}'...")
+    try:
+        pipe = ShapEImg2ImgPipeline.from_pretrained(model_name, torch_dtype=torch_dtype)
+        pipe = pipe.to(device)
+        print("✅ Pipeline loaded successfully.")
+        is_pipe_loaded = True
+    except Exception as e:
+        print(f"❌ Failed to load the Shap-E pipeline: {e}")
+        pipe = None
+        is_pipe_loaded = False
+
+def generate_3d_model_from_image(image_path: str, output_dir: str = "Examples/generated_models") -> str:
+    """
+    Generates a 3D model from an image file using the Shap-E model.
+    If the model generation fails, it returns a string containing an error message.
+    """
+    # Initialize the pipeline on the first call.
+    if not is_pipe_loaded:
+        initialize_pipeline()
+
+    if not pipe:
+        return "Error: Shap-E pipeline is not available. Check logs for details."
+
+    print(f"🐍 Generating 3D model for image: '{image_path}'...")
+
+    # --- Load the input image ---
+    try:
+        input_image = load_image(image_path)
+        print(f"✅ Image loaded successfully from: {image_path}")
+    except Exception as e:
+        error_message = f"Error: Failed to load image at '{image_path}'. Reason: {e}"
+        print(f"❌ {error_message}")
+        return error_message
+
+
+    # --- Create output directory if it doesn't exist ---
+    os.makedirs(output_dir, exist_ok=True)
+
+    # --- Generate a unique filename to avoid overwriting ---
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # Sanitize the image filename to create a valid, short filename.
+    base_filename = os.path.splitext(os.path.basename(image_path))[0]
+    sanitized_filename = "".join(c for c in base_filename if c.isalnum() or c in (' ', '_')).rstrip()
+    sanitized_filename = sanitized_filename.replace(' ', '_')[:30]
+    filename = f"{timestamp}_{sanitized_filename}.ply"
+    output_path = os.path.join(output_dir, filename)
+
+    # --- Run the model inference ---
+    try:
+        # The guidance_scale and num_inference_steps are key parameters to tune quality vs. speed.
+        images = pipe(
+            input_image,
+            guidance_scale=3.0,
+            num_inference_steps=64,
+            frame_size=256,
+            output_type="mesh"  # Request a mesh output directly
+        ).images
+
+        if not images:
+            raise ValueError("Model did not return any images/meshes.")
+
+        mesh = images[0]
+
+        # --- Save the generated mesh to a .ply file ---
+        export_to_ply(mesh, output_path)
+
+        print(f"✅ Model saved successfully to: {output_path}")
+        return output_path
+
+    except Exception as e:
+        print(f"❌ An error occurred during model generation: {e}")
+        return f"Error: {e}"
+
+if __name__ == '__main__':
+    # This block allows for testing the script directly from the command line.
+    # Example: python Python/ai_models/image_to_3d.py
+    print("\n--- Running standalone test of image_to_3d.py ---")
+
+    # Create a dummy image for testing if one doesn't exist.
+    test_image_path = "Examples/test_image.png"
+    if not os.path.exists(test_image_path):
+        print(f"Creating a dummy test image at: {test_image_path}")
+        try:
+            os.makedirs(os.path.dirname(test_image_path), exist_ok=True)
+            dummy_image = Image.new('RGB', (100, 100), color = 'red')
+            dummy_image.save(test_image_path)
+            print("✅ Dummy image created.")
+        except Exception as e:
+            print(f"❌ Failed to create dummy image: {e}")
+            test_image_path = None
+
+    if test_image_path:
+        test_output_dir = "Examples/generated_models_test"
+        print(f"Test image: '{test_image_path}'")
+        print(f"Test output directory: '{test_output_dir}'")
+
+        path = generate_3d_model_from_image(test_image_path, output_dir=test_output_dir)
+
+        if path and "Error" not in path:
+            print(f"\n✅ Test successful! Model saved at: {path}")
+            print(f"You can view the generated .ply file in the '{test_output_dir}' directory using a 3D viewer like MeshLab or Blender.")
+        else:
+            print(f"\n❌ Test failed. Reason: {path}")
+    else:
+        print("\n❌ Test skipped because no test image was available.")


### PR DESCRIPTION
This commit introduces a new feature that allows you to generate 3D models from 2D images.

The implementation includes:
- A new SwiftUI view (`ImageTo3DView`) for the user interface, which allows selecting an image and previewing the generated model.
- A Python script (`image_to_3d.py`) that uses the `openai/shap-e-img2img` model from Hugging Face to perform the 3D generation.
- A Swift class (`ImageTo3DGenerator`) that acts as a bridge between the Swift UI and the Python backend.
- Integration of the new feature into the main application's navigation sidebar.

The implementation follows the existing architecture of the application and includes error handling and user feedback mechanisms.