### PR TITLE
feat: Add GLTF export functionality

### DIFF
--- a/MacForge3D/core/AI/PythonManager.swift
+++ b/MacForge3D/core/AI/PythonManager.swift
@@ -31,10 +31,16 @@ class PythonManager {
 
         let sys = Python.import("sys")
 
-        // Add the directory containing our AI models to Python's path
-        let scriptsPath = URL(fileURLWithPath: projectRoot).appendingPathComponent("Python/ai_models").path
-        if !sys.path.hell.contains(scriptsPath) {
-            sys.path.append(scriptsPath)
+        // Add project-specific Python directories to the path
+        let pythonRoot = URL(fileURLWithPath: projectRoot).appendingPathComponent("Python")
+        let aiModelsPath = pythonRoot.appendingPathComponent("ai_models").path
+        let exportersPath = pythonRoot.appendingPathComponent("exporters").path
+
+        if !sys.path.hell.contains(aiModelsPath) {
+            sys.path.append(aiModelsPath)
+        }
+        if !sys.path.hell.contains(exportersPath) {
+            sys.path.append(exportersPath)
         }
 
         print("✅ Python initialized successfully.")

--- a/MacForge3D/export/ModelExporter.swift
+++ b/MacForge3D/export/ModelExporter.swift
@@ -1,4 +1,21 @@
 import Foundation
+import PythonKit
+
+// Assuming Model3D is a typealias for Shape3D for now.
+typealias Model3D = Shape3D
+
+extension Shape3D {
+    func toDictionary() -> [String: [[String: [String: [Float]]]]] {
+        let trianglesData = mesh.triangles.map { triangle -> [String: [String: [Float]]] in
+            let v1Data = ["position": [triangle.v1.position.x, triangle.v1.position.y, triangle.v1.position.z], "normal": [triangle.normal.x, triangle.normal.y, triangle.normal.z]]
+            let v2Data = ["position": [triangle.v2.position.x, triangle.v2.position.y, triangle.v2.position.z], "normal": [triangle.normal.x, triangle.normal.y, triangle.normal.z]]
+            let v3Data = ["position": [triangle.v3.position.x, triangle.v3.position.y, triangle.v3.position.z], "normal": [triangle.normal.x, triangle.normal.y, triangle.normal.z]]
+            return ["v1": v1Data, "v2": v2Data, "v3": v3Data]
+        }
+        return ["triangles": trianglesData]
+    }
+}
+
 
 class ModelExporter {
     func export(model: Model3D, to url: URL, format: ModelFormat) -> Bool {
@@ -26,8 +43,18 @@ class ModelExporter {
     }
 
     private func exportGLTF(_ model: Model3D, _ url: URL) -> Bool {
-        // Implémenter l'export GLTF
-        return false
+        PythonManager.initialize()
+
+        let meshData = model.toDictionary()
+
+        do {
+            let gltfExporter = Python.import("gltf_exporter")
+            gltfExporter.export_to_gltf(meshData, url.path)
+            return true
+        } catch {
+            print("Error exporting to GLTF: \(error)")
+            return false
+        }
     }
 
     private func exportSTL(_ model: Model3D, _ url: URL) -> Bool {

--- a/Python/exporters/gltf_exporter.py
+++ b/Python/exporters/gltf_exporter.py
@@ -1,0 +1,94 @@
+import json
+import sys
+import numpy as np
+import pygltflib
+
+def create_indexed_mesh(triangles):
+    """Converts a list of triangles to an indexed mesh."""
+    vertices = []
+    indices = []
+    vertex_map = {}
+
+    for triangle in triangles:
+        for vertex_data in [triangle['v1'], triangle['v2'], triangle['v3']]:
+            pos = tuple(vertex_data['position'])
+            if pos not in vertex_map:
+                vertex_map[pos] = len(vertices)
+                vertices.append(vertex_data)
+            indices.append(vertex_map[pos])
+
+    return vertices, indices
+
+def export_to_gltf(mesh_data, output_path):
+    """Exports mesh data from a dictionary to a GLTF 2.0 file."""
+    triangles = mesh_data.get('triangles', [])
+    if not triangles:
+        print("No triangles found in mesh data.", file=sys.stderr)
+        return
+
+    vertices, indices = create_indexed_mesh(triangles)
+
+    positions = np.array([v['position'] for v in vertices], dtype=np.float32)
+    normals = np.array([v['normal'] for v in vertices], dtype=np.float32)
+    indices = np.array(indices, dtype=np.uint32)
+
+    # Convert numpy arrays to bytes
+    positions_blob = positions.tobytes()
+    normals_blob = normals.tobytes()
+    indices_blob = indices.tobytes()
+
+    gltf = pygltflib.GLTF2()
+
+    # Scene
+    gltf.scenes.append(pygltflib.Scene(nodes=[0]))
+    gltf.scene = 0
+
+    # Nodes
+    gltf.nodes.append(pygltflib.Node(mesh=0))
+
+    # Mesh
+    gltf.meshes.append(pygltflib.Mesh(primitives=[pygltflib.Primitive(
+        attributes=pygltflib.Attributes(POSITION=0, NORMAL=1),
+        indices=2
+    )]))
+
+    # Accessors
+    gltf.accessors.extend([
+        pygltflib.Accessor(
+            bufferView=0,
+            componentType=pygltflib.FLOAT,
+            count=len(positions),
+            type=pygltflib.VEC3,
+            min=positions.min(axis=0).tolist(),
+            max=positions.max(axis=0).tolist()
+        ),
+        pygltflib.Accessor(
+            bufferView=1,
+            componentType=pygltflib.FLOAT,
+            count=len(normals),
+            type=pygltflib.VEC3
+        ),
+        pygltflib.Accessor(
+            bufferView=2,
+            componentType=pygltflib.UNSIGNED_INT,
+            count=len(indices),
+            type=pygltflib.SCALAR
+        )
+    ])
+
+    # BufferViews
+    gltf.bufferViews.extend([
+        pygltflib.BufferView(buffer=0, byteOffset=0, byteLength=len(positions_blob), target=pygltflib.ARRAY_BUFFER),
+        pygltflib.BufferView(buffer=0, byteOffset=len(positions_blob), byteLength=len(normals_blob), target=pygltflib.ARRAY_BUFFER),
+        pygltflib.BufferView(buffer=0, byteOffset=len(positions_blob) + len(normals_blob), byteLength=len(indices_blob), target=pygltflib.ELEMENT_ARRAY_BUFFER)
+    ])
+
+    # Buffer
+    gltf.buffers.append(pygltflib.Buffer(byteLength=len(positions_blob) + len(normals_blob) + len(indices_blob)))
+    gltf.set_binary_blob(positions_blob + normals_blob + indices_blob)
+
+    # Save to file
+    gltf.save(output_path)
+
+
+# This script is intended to be imported as a module.

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -11,6 +11,9 @@ shapely>=2.0.0
 manifold3d>=1.2.0
 librosa==0.11.0
 
+# 3D Model Exporting
+pygltflib==1.15.3
+
 # Testing
 pytest==8.0.0
 soundfile==0.13.1

--- a/Tests/MacForge3DTests/ExporterTests.swift
+++ b/Tests/MacForge3DTests/ExporterTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import MacForge3D
+
+class ExporterTests: XCTestCase {
+
+    func testExportGLTF() throws {
+        // 1. Create a simple mesh (a single triangle)
+        let v1 = Vertex(position: SIMD3<Float>(0, 1, 0), normal: SIMD3<Float>(0, 0, 1), uv: SIMD2<Float>(0, 1))
+        let v2 = Vertex(position: SIMD3<Float>(-1, -1, 0), normal: SIMD3<Float>(0, 0, 1), uv: SIMD2<Float>(-1, -1))
+        let v3 = Vertex(position: SIMD3<Float>(1, -1, 0), normal: SIMD3<Float>(0, 0, 1), uv: SIMD2<Float>(1, -1))
+        let triangle = Triangle(v1: v1, v2: v2, v3: v3, normal: SIMD3<Float>(0, 0, 1))
+        let mesh = Mesh(vertices: [v1, v2, v3], triangles: [triangle])
+        let shape = Shape3D(name: "TestTriangle", mesh: mesh, material: Material(name: "Default"))
+
+        // 2. Get a temporary URL for the output file
+        let temporaryDirectoryURL = FileManager.default.temporaryDirectory
+        let fileURL = temporaryDirectoryURL.appendingPathComponent("test.gltf")
+
+        // 3. Export the model
+        let exporter = ModelExporter()
+        let success = exporter.export(model: shape, to: fileURL, format: .gltf)
+
+        // 4. Assert that the export was successful
+        XCTAssertTrue(success, "GLTF export should succeed.")
+
+        // 5. Assert that the file was created and is not empty
+        var isDirectory: ObjCBool = false
+        let fileExists = FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory)
+        XCTAssertTrue(fileExists, "The GLTF file should exist.")
+        XCTAssertFalse(isDirectory.boolValue, "The path should point to a file, not a directory.")
+
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let fileSize = fileAttributes[FileAttributeKey.size] as? NSNumber
+        XCTAssertNotNil(fileSize, "File size should be readable.")
+        XCTAssertGreaterThan(fileSize?.intValue ?? 0, 0, "GLTF file should not be empty.")
+
+        // Clean up the file
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}


### PR DESCRIPTION
This change adds the capability to export 3D models to the GLTF format.

It introduces a new Python script that uses the `pygltflib` library to perform the export. The main Swift code has been updated to call this script.

A unit test has been added, but I could not run it due to issues with the test environment.