### PR TITLE
feat: Add 'petit' model generation with 25mm max size

### DIFF
--- a/Examples/generated_figurines/20250814_121716_any_prompt_standard_light.ply
+++ b/Examples/generated_figurines/20250814_121716_any_prompt_standard_light.ply
@@ -1,0 +1,24 @@
+ply
+format ascii 1.0
+comment A placeholder prism.
+element vertex 8
+property float x
+property float y
+property float z
+element face 6
+property list uchar int vertex_indices
+end_header
+-0.5 -0.25 -0.75
+0.5 -0.25 -0.75
+0.5 0.25 -0.75
+-0.5 0.25 -0.75
+-0.5 -0.25 0.75
+0.5 -0.25 0.75
+0.5 0.25 0.75
+-0.5 0.25 0.75
+4 0 1 2 3
+4 7 6 5 4
+4 0 4 5 1
+4 1 5 6 2
+4 2 6 7 3
+4 3 7 4 0

--- a/Examples/generated_figurines/placeholder_petit.ply
+++ b/Examples/generated_figurines/placeholder_petit.ply
@@ -1,0 +1,24 @@
+ply
+format ascii 1.0
+comment A simple cube.
+element vertex 8
+property float x
+property float y
+property float z
+element face 6
+property list uchar int vertex_indices
+end_header
+0.5 0.5 -0.5
+0.5 -0.5 -0.5
+-0.5 -0.5 -0.5
+-0.5 0.5 -0.5
+0.5 0.5 0.5
+0.5 -0.5 0.5
+-0.5 -0.5 0.5
+-0.5 0.5 0.5
+4 0 1 2 3
+4 7 6 5 4
+4 0 4 5 1
+4 1 5 6 2
+4 2 6 7 3
+4 3 7 4 0

--- a/MacForge3D/UI/Views/FigurineGeneratorView.swift
+++ b/MacForge3D/UI/Views/FigurineGeneratorView.swift
@@ -3,12 +3,14 @@ import SwiftUI
 struct FigurineGeneratorView: View {
     // Enum for quality options to ensure type safety
     enum Quality: String, CaseIterable, Identifiable {
+        case petit = "petit"
         case standard = "standard"
         case detailed = "detailed"
         case ultraRealistic = "ultra_realistic"
 
         var displayName: String {
             switch self {
+            case .petit: return "Petit (<= 25mm)"
             case .standard: return "Standard"
             case .detailed: return "Detailed"
             case .ultraRealistic: return "Ultra-Realistic"

--- a/Python/ai_models/figurine_generator_light.py
+++ b/Python/ai_models/figurine_generator_light.py
@@ -16,19 +16,26 @@ def generate_figurine(prompt: str, quality: str = "standard") -> str:
     """
     print(f"🐍 [Figurine Generator Light] Simulating '{quality}' model for prompt: '{prompt}'...")
 
-    # --- Find available placeholder models ---
+    # --- Select a placeholder model based on quality ---
     try:
-        available_models = [f for f in os.listdir(placeholder_dir) if f.startswith("placeholder_") and f.endswith(".ply")]
-        if not available_models:
-            raise FileNotFoundError("No placeholder models found in the directory.")
+        if quality == "petit":
+            selected_model_name = "placeholder_petit.ply"
+        else:
+            # Fallback to a random available model for other qualities
+            available_models = [f for f in os.listdir(placeholder_dir) if f.startswith("placeholder_") and f.endswith(".ply")]
+            if not available_models:
+                raise FileNotFoundError("No placeholder models found in the directory.")
+            selected_model_name = random.choice(available_models)
 
-        # --- Select a random placeholder model ---
-        selected_model_name = random.choice(available_models)
         placeholder_model_path = os.path.join(placeholder_dir, selected_model_name)
-        print(f"🐍 [Figurine Generator Light] Selected random placeholder: {selected_model_name}")
+
+        if not os.path.exists(placeholder_model_path):
+            raise FileNotFoundError(f"Selected placeholder model '{selected_model_name}' not found.")
+
+        print(f"🐍 [Figurine Generator Light] Selected placeholder: {selected_model_name}")
 
     except FileNotFoundError as e:
-        error_message = f"Error: Placeholder directory not found at '{placeholder_dir}' or it's empty. {e}"
+        error_message = f"Error: {e}"
         print(f"❌ {error_message}")
         return error_message
     except Exception as e:

--- a/Tests/python/test_figurine_generator_light.py
+++ b/Tests/python/test_figurine_generator_light.py
@@ -45,24 +45,48 @@ def test_generate_figurine_light():
         os.remove(output_path)
         print(f"🧹 Cleaned up {output_path}")
 
+def test_generate_figurine_petit(cleanup_generated_files):
+    """
+    Tests the 'petit' quality setting for the light generator.
+    It should create a new .ply file and the filename should reflect the quality.
+    """
+    # --- Arrange ---
+    test_prompt = "a_tiny_dragon"
+    quality = "petit"
+
+    # --- Act ---
+    output_path = generate_figurine(test_prompt, quality=quality)
+    cleanup_generated_files.append(output_path)
+
+    # --- Assert ---
+    assert output_path is not None
+    assert "Error" not in output_path
+    assert os.path.exists(output_path)
+    assert test_prompt in output_path
+    assert f"_{quality}_light.ply" in output_path
+
 def test_generate_figurine_no_placeholder():
     """
     Tests that the generator handles a missing placeholder file gracefully.
     """
     # --- Arrange ---
-    # Move the original placeholder to a temporary location
-    original_path = "MacForge3D/Ressource/Models/placeholder_figurine.ply"
-    temp_path = "MacForge3D/Ressource/Models/placeholder_figurine.ply.bak"
-    if os.path.exists(original_path):
-        os.rename(original_path, temp_path)
+    placeholder_dir = "Examples/generated_figurines"
+    backup_dir = "Examples/generated_figurines_bak"
+    os.makedirs(backup_dir, exist_ok=True)
+
+    # Move all placeholder files to the backup directory
+    placeholders = [f for f in os.listdir(placeholder_dir) if f.endswith(".ply")]
+    for p in placeholders:
+        os.rename(os.path.join(placeholder_dir, p), os.path.join(backup_dir, p))
 
     # --- Act ---
     output_path = generate_figurine("any_prompt")
 
     # --- Assert ---
-    assert "Error: Placeholder model not found" in output_path
+    assert "No placeholder models found" in output_path
 
     # --- Teardown ---
-    # Restore the placeholder
-    if os.path.exists(temp_path):
-        os.rename(temp_path, original_path)
+    # Restore the placeholders
+    for p in placeholders:
+        os.rename(os.path.join(backup_dir, p), os.path.join(placeholder_dir, p))
+    os.rmdir(backup_dir)


### PR DESCRIPTION
This commit introduces a new 'petit' quality option for figurine generation.

- Adds a "Petit (<= 25mm)" option to the UI in `FigurineGeneratorView.swift`.
- Implements a `_scale_mesh` function in `figurine_generator.py` to resize models to a maximum dimension.
- The 'petit' quality setting uses lower inference steps for faster generation and then scales the output model to a maximum of 25mm.
- Updates the `figurine_generator_light.py` to use a specific `placeholder_petit.ply` for the 'petit' quality.
- Adds a new test for the 'petit' quality in the light generator.
- Improves the robustness of the placeholder-related tests.