### PR TITLE
Fix export functionality in Toolbar

### DIFF
--- a/MacForge3D/Appcontroller.swift
+++ b/MacForge3D/Appcontroller.swift
@@ -32,6 +32,31 @@ class AppController: ObservableObject {
         _ = modelExporter.export(model: model, to: url, format: format)
     }
 
+    func exportCurrentSceneToData(format: ModelFormat) -> Data? {
+        guard let model = sceneManager.currentScene() else { return nil }
+
+        // Create a temporary file URL
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        // Export the model to the temporary file
+        let success = modelExporter.export(model: model, to: tempURL, format: format)
+
+        if success {
+            do {
+                // Read the data from the temporary file
+                let data = try Data(contentsOf: tempURL)
+                // Clean up the temporary file
+                try? FileManager.default.removeItem(at: tempURL)
+                return data
+            } catch {
+                print("Error reading exported file: \(error)")
+                return nil
+            }
+        } else {
+            return nil
+        }
+    }
+
     // Exemple : activer un plugin
     func activatePlugin(named name: String) {
         pluginManager.activate(pluginNamed: name)

--- a/MacForge3D/UI/Toolbar.swift
+++ b/MacForge3D/UI/Toolbar.swift
@@ -21,9 +21,10 @@ struct Toolbar: View {
             .help("Importer un modèle")
 
             Button(action: {
-                let placeholderData = "Ceci est un test d'exportation".data(using: .utf8) ?? Data()
-                document = ExportedFile(data: placeholderData)
-                isExporting = true
+                if let data = appController.exportCurrentSceneToData(format: .gltf) {
+                    document = ExportedFile(data: data)
+                    isExporting = true
+                }
             }) {
                 Image(systemName: "square.and.arrow.up")
             }
@@ -80,8 +81,8 @@ struct Toolbar: View {
         .fileExporter(
             isPresented: $isExporting,
             document: document,
-            contentType: .plainText, // TODO: Changer pour le type de fichier 3D approprié
-            defaultFilename: "mon_modele.txt" // TODO: Changer l'extension
+            contentType: .gltf,
+            defaultFilename: "model.gltf"
         ) { result in
             switch result {
             case .success(let url):
@@ -90,5 +91,11 @@ struct Toolbar: View {
                 print("Erreur d'exportation: \(error.localizedDescription)")
             }
         }
+    }
+}
+
+extension UTType {
+    static var gltf: UTType {
+        UTType(exportedAs: "com.example.gltf")
     }
 }

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -100,6 +100,19 @@ echo "✅ Virtual environment created."
 echo "› Activating virtual environment and installing Python packages..."
 source "$VENV_DIR/bin/activate"
 
+# Explicitly set the C/C++ compiler. The torchmcubes build fails if CXX is
+# set to a non-existent compiler (like g++-11). We force it to use the
+# compiler installed by Homebrew.
+if [ -f "$BREW_PREFIX/bin/g++-15" ]; then
+    export CXX="$BREW_PREFIX/bin/g++-15"
+    export CC="$BREW_PREFIX/bin/gcc-15"
+else
+    export CXX="$BREW_PREFIX/bin/g++"
+    export CC="$BREW_PREFIX/bin/gcc"
+fi
+
+echo "› Using CXX=$CXX and CC=$CC for build."
+
 pip install --upgrade pip
 
 # Install packages from requirements.txt


### PR DESCRIPTION
This commit fixes the export functionality in the `Toolbar` by:

- Implementing a new method `exportCurrentSceneToData` in `AppController` to handle the export of the current scene to a `Data` object.
- Updating `Toolbar.swift` to use this new method for exporting to GLTF format.
- Setting the correct `UTType` and default filename for GLTF export.